### PR TITLE
Restore compatibility with Laravel < 8.66

### DIFF
--- a/src/OrderableCollection.php
+++ b/src/OrderableCollection.php
@@ -46,7 +46,7 @@ class OrderableCollection extends EloquentCollection
     public function setOrder($ids)
     {
         $count = $this->count();
-        $isList = Arr::isList($this->keys()->all());
+        $isList = ! Arr::isAssoc($this->keys()->all());
 
         return $this->sortBy(function ($item) use ($ids, $count) {
             $index = array_search($item->getKey(), $ids);


### PR DESCRIPTION
`OrderableCollection::setOrder()` calls `Arr::isList()`, which was only added in Laravel 8.66.0, so it fatals on the 8.0–8.65 range still allowed by `^8.0`.