### PR TITLE
Fix/fix positions command exit codes

### DIFF
--- a/src/Concerns/HasOrderableRelationships.php
+++ b/src/Concerns/HasOrderableRelationships.php
@@ -35,7 +35,7 @@ trait HasOrderableRelationships
      * @param string $relatedKey
      * @param string $relation
      *
-     * @return BelongsToSortedMany
+     * @return BelongsToManyOrderable
      */
     public function belongsToManyOrderable(
         $related,

--- a/src/Console/FixPositionsCommand.php
+++ b/src/Console/FixPositionsCommand.php
@@ -15,27 +15,26 @@ class FixPositionsCommand extends Command
 
     protected $chunks = 200;
 
-    public function handle()
+    public function handle(): int
     {
         $model = $this->argument('model');
         $relationName = $this->argument('relationName');
         if (!class_exists($model) || !is_subclass_of($model, Model::class)) {
             $this->error($model . ' is not a valid model class!');
-            return;
+            return static::FAILURE;
         }
         $instance = new $model();
 
         // If the relation name is provided, then we're fixing an ordered relation:
         if ($relationName) {
-            $this->fixRelation($instance, $relationName);
-            return;
+            return $this->fixRelation($instance, $relationName);
         }
         // else, it's an orderable model.
 
         // Let's check that the model uses the Orderable trait:
         if (!method_exists($model, 'getOrderColumn')) {
             $this->error('{model} must be a valid model class and use the Orderable trait!');
-            return;
+            return static::FAILURE;
         }
 
         // The treatment will be different whether the model is groupable or not:
@@ -45,6 +44,7 @@ class FixPositionsCommand extends Command
             $this->fixUngroupable($instance);
         }
         $this->info('Done!');
+        return static::SUCCESS;
     }
 
     protected function fixUngroupable($instance)
@@ -74,17 +74,17 @@ class FixPositionsCommand extends Command
         });
     }
 
-    protected function fixRelation($instance, $relationName)
+    protected function fixRelation($instance, $relationName): int
     {
         try {
             $relation = $instance->$relationName();
             if (!$relation instanceof BelongsToManyOrderable) {
                 $this->error($relationName . ' is not a valid belongs-to-many-ordered relationship!');
-                return;
+                return static::FAILURE;
             }
         } catch (\Exception $e) {
             $this->error($relationName . ' is not a valid relationship!');
-            return;
+            return static::FAILURE;
         }
 
         $query = $instance->newQuery()
@@ -104,6 +104,7 @@ class FixPositionsCommand extends Command
                 $this->line("<info>Fixed for model:</info> {$item->getKey()}");
             }
         });
+        return static::SUCCESS;
     }
 
     protected function fixPositions($query, $instance)

--- a/tests/ConsoleTest.php
+++ b/tests/ConsoleTest.php
@@ -82,4 +82,28 @@ class ConsoleTest extends TestCase
         ]);
         $this->assertEquals([1, 2, 3, 4, 5], $article->tags()->ordered()->get()->pluck('pivot.position')->all());
     }
+
+    public function test_fix_positions_returns_success_exit_code()
+    {
+        Tag::factory()->count(3)->create();
+
+        $this->artisan('orderly:fix-positions', ['model' => Tag::class])
+            ->assertExitCode(0);
+    }
+
+    public function test_fix_positions_fails_on_invalid_model()
+    {
+        $this->artisan('orderly:fix-positions', ['model' => 'NotAModelClass'])
+            ->assertExitCode(1);
+    }
+
+    public function test_fix_positions_fails_on_invalid_relation()
+    {
+        Article::factory()->create();
+
+        $this->artisan('orderly:fix-positions', [
+            'model' => Article::class,
+            'relationName' => 'doesNotExist',
+        ])->assertExitCode(1);
+    }
 }


### PR DESCRIPTION
`FixPositionsCommand` returned `null` on error branches → exit code `0` (false success). Now returns `FAILURE`/`SUCCESS` on every path + tests.

Fixed `@return BelongsToSortedMany` (nonexistent class) → `BelongsToManyOrderable` on `belongsToManyOrderable()`.